### PR TITLE
Fix bugs with friend request system

### DIFF
--- a/app/src/main/java/com/github/se/stepquest/Friend.kt
+++ b/app/src/main/java/com/github/se/stepquest/Friend.kt
@@ -2,4 +2,8 @@ package com.github.se.stepquest
 
 import android.net.Uri
 
-data class Friend(val name: String, val profilePicture: Uri?, val status: Boolean)
+data class Friend(
+    val name: String = "",
+    val profilePicture: Uri? = null,
+    val status: Boolean = false
+)

--- a/app/src/main/java/com/github/se/stepquest/services/FriendsServices.kt
+++ b/app/src/main/java/com/github/se/stepquest/services/FriendsServices.kt
@@ -199,29 +199,7 @@ fun sendFriendRequest(currentUsername: String, friendName: String) {
 
   // Retrieve the new friend's uid
   val usernamesRef = database.reference.child("usernames")
-  // Send notification
-  val senderUserId = userRepository.getUid().toString()
-  usernamesRef
-      .child(friendName)
-      .addListenerForSingleValueEvent(
-          object : ValueEventListener {
-            override fun onDataChange(snapshot: DataSnapshot) {
-              println("Snapshot: ${snapshot.value}")
-              val receiverUserId = snapshot.value.toString()
-              notificationRepository.createNotification(
-                  receiverUserId,
-                  NotificationData(
-                      "You received new friend request from $currentUsername!",
-                      LocalDateTime.now().format(DateTimeFormatter.ofPattern("HH:mm")),
-                      UUID.randomUUID().toString(),
-                      receiverUserId,
-                      senderUserId))
-            }
 
-            override fun onCancelled(error: DatabaseError) {
-              TODO("Not yet implemented")
-            }
-          })
   usernamesRef.addListenerForSingleValueEvent(
       object : ValueEventListener {
         override fun onDataChange(snapshot: DataSnapshot) {
@@ -238,6 +216,31 @@ fun sendFriendRequest(currentUsername: String, friendName: String) {
                   if (currentUsername in pendingRequests) return
                   pendingRequests.add(currentUsername)
                   friendRequestsRef.setValue(pendingRequests)
+
+                  // Send notification
+                  val senderUserId = userRepository.getUid().toString()
+                  usernamesRef
+                      .child(friendName)
+                      .addListenerForSingleValueEvent(
+                          object : ValueEventListener {
+                            override fun onDataChange(snapshot: DataSnapshot) {
+                              println("Snapshot: ${snapshot.value}")
+                              val receiverUserId = snapshot.value.toString()
+                              notificationRepository.createNotification(
+                                  receiverUserId,
+                                  NotificationData(
+                                      "You received new friend request from $currentUsername!",
+                                      LocalDateTime.now()
+                                          .format(DateTimeFormatter.ofPattern("HH:mm")),
+                                      UUID.randomUUID().toString(),
+                                      receiverUserId,
+                                      senderUserId))
+                            }
+
+                            override fun onCancelled(error: DatabaseError) {
+                              TODO("Not yet implemented")
+                            }
+                          })
                 }
 
                 override fun onCancelled(error: DatabaseError) {


### PR DESCRIPTION
I made the friend system work for good, including the addFriend call when accepting a friend request in the notifications.

**NOTE**: part of the problem was the fact that Uri objects can't be stored (at least not as is) on Firebase; we need to come up with a different solution for friend pfp storage, or even drop them entirely at this stage.