### PR TITLE
Cache login info

### DIFF
--- a/app/src/main/java/com/github/se/stepquest/Navigation.kt
+++ b/app/src/main/java/com/github/se/stepquest/Navigation.kt
@@ -28,7 +28,7 @@ import com.github.se.stepquest.map.LocationViewModel
 import com.github.se.stepquest.map.Map
 import com.github.se.stepquest.screens.ChallengesScreen
 import com.github.se.stepquest.screens.DatabaseLoadingScreen
-import com.github.se.stepquest.screens.FriendsListScreen
+import com.github.se.stepquest.screens.FriendsListScreenCheck
 import com.github.se.stepquest.screens.HomeScreen
 import com.github.se.stepquest.screens.LoginScreen
 import com.github.se.stepquest.screens.NewPlayerScreen
@@ -90,7 +90,7 @@ fun AppNavigationHost(
       modifier = modifier,
       navController = navigationController,
       startDestination = startDestination) {
-        composable(Routes.LoginScreen.routName) { LoginScreen(navigationActions) }
+        composable(Routes.LoginScreen.routName) { LoginScreen(navigationActions, context) }
         composable(Routes.DatabaseLoadingScreen.routName) {
           DatabaseLoadingScreen(navigationActions, startServiceLambda, userId)
         }
@@ -98,14 +98,14 @@ fun AppNavigationHost(
           NewPlayerScreen(navigationActions, context, userId)
         }
         composable(Routes.MainScreen.routName) { BuildMainScreen() }
-        composable(Routes.HomeScreen.routName) { HomeScreen(navigationActions, userId) }
+        composable(Routes.HomeScreen.routName) { HomeScreen(navigationActions, userId, context) }
         composable(Routes.ProgressionScreen.routName) { ProgressionPage(IUserRepository()) }
         composable(Routes.MapScreen.routName) { Map(locationviewModel) }
         composable(Routes.ProfileScreen.routName) {
-          ProfilePageLayout(navigationActions, userId, profilePictureUrl)
+          ProfilePageLayout(navigationActions, userId, profilePictureUrl, context)
         }
         composable(Routes.FriendsListScreen.routName) {
-          FriendsListScreen(navigationActions = navigationActions, userId)
+          FriendsListScreenCheck(navigationActions = navigationActions, userId, context = context)
         }
         composable(Routes.NotificationScreen.routName) { NotificationScreen(IUserRepository()) }
         composable(Routes.ChallengeScreen.routName) { ChallengesScreen(userId, navigationActions) }

--- a/app/src/main/java/com/github/se/stepquest/ProfilePage.kt
+++ b/app/src/main/java/com/github/se/stepquest/ProfilePage.kt
@@ -1,5 +1,6 @@
 package com.github.se.stepquest
 
+import android.content.Context
 import android.net.Uri
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
@@ -34,6 +35,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.rememberAsyncImagePainter
+import com.github.se.stepquest.services.getCachedInfo
+import com.github.se.stepquest.services.isOnline
 import com.github.se.stepquest.ui.navigation.NavigationActions
 import com.github.se.stepquest.ui.navigation.TopLevelDestination
 import com.google.firebase.Firebase
@@ -43,36 +46,48 @@ import com.google.firebase.database.ValueEventListener
 import com.google.firebase.database.database
 
 @Composable
-fun ProfilePageLayout(navigationActions: NavigationActions, userId: String, profilePicture: Uri?) {
+fun ProfilePageLayout(
+    navigationActions: NavigationActions,
+    userId: String,
+    profilePicture: Uri?,
+    context: Context
+) {
   val blueThemeColor = colorResource(id = R.color.blueTheme)
   var totalStepsMade by remember { mutableIntStateOf(0) }
   var username by remember { mutableStateOf("No name") }
-  val database = Firebase.database
-  val databaseRef = database.reference.child("users")
-  val stepsRef = databaseRef.child(userId).child("totalSteps")
-  stepsRef.addListenerForSingleValueEvent(
-      object : ValueEventListener {
-        override fun onDataChange(dataSnapshot: DataSnapshot) {
-          totalStepsMade = dataSnapshot.getValue(Int::class.java) ?: 0
-        }
 
-        override fun onCancelled(databaseError: DatabaseError) {
-          // add code when failing to access database
-        }
-      })
-  val usernameRef = databaseRef.child(userId).child("username")
+  if (isOnline(context)) {
+    val database = Firebase.database
+    val databaseRef = database.reference.child("users")
+    val stepsRef = databaseRef.child(userId).child("totalSteps")
+    stepsRef.addListenerForSingleValueEvent(
+        object : ValueEventListener {
+          override fun onDataChange(dataSnapshot: DataSnapshot) {
+            totalStepsMade = dataSnapshot.getValue(Int::class.java) ?: 0
+          }
 
-  usernameRef.addListenerForSingleValueEvent(
-      object : ValueEventListener {
-        override fun onDataChange(dataSnapshot: DataSnapshot) {
-          username = dataSnapshot.getValue(String::class.java) ?: "No name"
-        }
+          override fun onCancelled(databaseError: DatabaseError) {
+            // add code when failing to access database
+          }
+        })
+    val usernameRef = databaseRef.child(userId).child("username")
 
-        override fun onCancelled(databaseError: DatabaseError) {
-          // add code when failing to access database
-        }
-      })
-  var showDialog by remember { mutableStateOf(false) }
+    usernameRef.addListenerForSingleValueEvent(
+        object : ValueEventListener {
+          override fun onDataChange(dataSnapshot: DataSnapshot) {
+            username = dataSnapshot.getValue(String::class.java) ?: "No name"
+          }
+
+          override fun onCancelled(databaseError: DatabaseError) {
+            // add code when failing to access database
+          }
+        })
+  } else {
+
+    val userInfo = getCachedInfo(context)
+    if (userInfo != null) username = userInfo.second
+  }
+
   Column(
       modifier = Modifier.padding(32.dp).fillMaxSize(),
       horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/java/com/github/se/stepquest/screens/FriendsList.kt
+++ b/app/src/main/java/com/github/se/stepquest/screens/FriendsList.kt
@@ -1,7 +1,9 @@
 package com.github.se.stepquest.screens
 
+import android.content.Context
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -32,13 +34,34 @@ import androidx.compose.ui.unit.sp
 import com.github.se.stepquest.Friend
 import com.github.se.stepquest.R
 import com.github.se.stepquest.Routes
+import com.github.se.stepquest.services.isOnline
 import com.github.se.stepquest.ui.navigation.NavigationActions
 import com.github.se.stepquest.ui.navigation.TopLevelDestination
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.DatabaseError
 import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.database.ValueEventListener
-import com.google.firebase.database.getValue
+
+@Composable
+fun FriendsListScreenCheck(
+    navigationActions: NavigationActions,
+    userId: String,
+    testCurrentFriendsList: List<Friend> = emptyList(),
+    context: Context
+) {
+
+  if (isOnline(context)) {
+    FriendsListScreen(navigationActions, userId, testCurrentFriendsList)
+  } else {
+
+    Box(modifier = Modifier.fillMaxSize().padding(16.dp), contentAlignment = Alignment.Center) {
+      Text(
+          text = "You must be online to view your friend list.",
+          color = Color.Red,
+          fontSize = 18.sp)
+    }
+  }
+}
 
 @Composable
 fun FriendsListScreen(
@@ -50,7 +73,7 @@ fun FriendsListScreen(
   var showAddFriendScreen by remember { mutableStateOf(false) }
   var showFriendProfile by remember { mutableStateOf(false) }
   var selectedFriend by remember { mutableStateOf<Friend?>(null) }
-  var currentFriendsList by remember { mutableStateOf(testCurrentFriendsList.toMutableList()) }
+  val currentFriendsList by remember { mutableStateOf(testCurrentFriendsList.toMutableList()) }
   val database = FirebaseDatabase.getInstance()
   if (currentFriendsList.isEmpty()) {
     val friendsListRef = database.reference.child("users").child(userId).child("friendsList")

--- a/app/src/main/java/com/github/se/stepquest/screens/HomeScreen.kt
+++ b/app/src/main/java/com/github/se/stepquest/screens/HomeScreen.kt
@@ -1,5 +1,6 @@
 package com.github.se.stepquest.screens
 
+import android.content.Context
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -37,12 +38,15 @@ import androidx.compose.ui.unit.sp
 import com.github.se.stepquest.Routes
 import com.github.se.stepquest.activity.Quest
 import com.github.se.stepquest.data.model.ChallengeData
+import com.github.se.stepquest.services.cacheUserInfo
 import com.github.se.stepquest.services.getTopChallenge
+import com.github.se.stepquest.services.getUsername
+import com.github.se.stepquest.services.isOnline
 import com.github.se.stepquest.ui.navigation.NavigationActions
 import com.github.se.stepquest.ui.navigation.TopLevelDestination
 
 @Composable
-fun HomeScreen(navigationActions: NavigationActions, userId: String) {
+fun HomeScreen(navigationActions: NavigationActions, userId: String, context: Context) {
 
   // Added for testing purposes ------
   var quests: List<Quest> by remember { mutableStateOf(emptyList()) }
@@ -56,6 +60,10 @@ fun HomeScreen(navigationActions: NavigationActions, userId: String) {
   }
 
   // ---------------------------------
+
+  val isOnline = isOnline(context)
+
+  if (isOnline) getUsername(userId) { cacheUserInfo(context, userId, it) }
 
   Scaffold(
       containerColor = Color(0xFF0D99FF),

--- a/app/src/main/java/com/github/se/stepquest/services/CacheFunctions.kt
+++ b/app/src/main/java/com/github/se/stepquest/services/CacheFunctions.kt
@@ -1,0 +1,33 @@
+package com.github.se.stepquest.services
+
+import android.content.Context
+import android.net.ConnectivityManager
+
+fun isOnline(context: Context): Boolean {
+
+  val manager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+  val networkInfo = manager.activeNetworkInfo
+
+  return networkInfo != null && networkInfo.isConnected
+}
+
+fun cacheUserInfo(context: Context, userId: String, username: String) {
+
+  val sharedPreferences = context.getSharedPreferences("UserData", Context.MODE_PRIVATE)
+
+  val editor = sharedPreferences.edit()
+  editor.putString("userId", userId)
+  editor.putString("username", username)
+  editor.apply()
+}
+
+fun getCachedInfo(context: Context): Pair<String, String>? {
+
+  val sharedPreferences = context.getSharedPreferences("UserData", Context.MODE_PRIVATE)
+
+  val userId = sharedPreferences.getString("userId", null)
+  val username = sharedPreferences.getString("username", null)
+
+  return if (userId != null && username != null) Pair(userId, username) else null
+}


### PR DESCRIPTION
Added a way to still login and access the app when offline. More specifically:

- If the user had previously logged in, the user ID and username are cached, so the application is still accessible
- If the user has never logged in, nothing is cached, so the application tells them to connect to the Internet and login once first
- The friends list is not accessible in offline mode; I think it's not necessary to cache since all friend interactions must be online